### PR TITLE
fix(ParaView): push_image for different viewtypes

### DIFF
--- a/trame_vtk/modules/paraview/__init__.py
+++ b/trame_vtk/modules/paraview/__init__.py
@@ -86,7 +86,7 @@ class Helper:
         )
 
     def push_image(self, view_proxy, reset_camera=False):
-        if view_proxy.EnableRenderOnInteraction:
+        if view_proxy.GetPropertyValue("EnableRenderOnInteraction"):
             view_proxy.EnableRenderOnInteraction = 0
 
         if reset_camera:


### PR DESCRIPTION
Not using a RenderView (e.g., a ChartView) as view for the vtkLocalRemoteView will crash, because "EnableRenderOnInteraction" might not be defined. "GetPropertyValue" will return None for a non-existing Property